### PR TITLE
added simplejson dependency to eos-social to ensure that it wil work on ...

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,6 +8,6 @@ Homepage: http://www.endlessm.com
 
 Package: eos-social
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, python(>=2.6), python-gtk2, python-webkit, python-setuptools, libgtk-3-dev, python-cheetah
+Depends: ${shlibs:Depends}, ${misc:Depends}, python(>=2.6), python-gtk2, python-webkit, python-setuptools, libgtk-3-dev, python-cheetah, python-simplejson
 Description: Endless Social Bar installation package, this package installs the Endless Social Bar
 


### PR DESCRIPTION
When trying to deploy this on the nexus 7 we got a runtime error saying that there was no simplejson module.  On standard Ubuntu installs this isn't a problem but apprently with the Ubuntu 13.04 for the Nexus 7 this package is not present.  So I added python-simplejson dependency to the debian package to ensure that it will be pulled in with the rest of the build so in future deployments, this won't be an issue.
