### PR TITLE
Change the check active state interval from 2500 ms to 100 ms.

### DIFF
--- a/src/ui/wm_inspect.py
+++ b/src/ui/wm_inspect.py
@@ -5,7 +5,7 @@ import wnck
 class WM_Inspect_MixIn(object):
 
 
-    CHECK_INTERVAL = 2500
+    CHECK_INTERVAL = 100
     def __init__(self):
         super(WM_Inspect_MixIn, self).__init__()
         gobject.timeout_add(self.CHECK_INTERVAL, self._check_active)


### PR DESCRIPTION
Causes the social bar to perceptibly "start up" much faster.
