### PR TITLE
Update state of Back/Forward buttons on "notify::uri"

### DIFF
--- a/EosSocial/socialBarView.js
+++ b/EosSocial/socialBarView.js
@@ -250,6 +250,8 @@ const SocialBarView = new Lang.Class({
             this._updateNavigationFlags));
         this._browser.connect('load-failed', Lang.bind(this,
             this._updateNavigationFlags));
+        this._browser.connect('notify::uri', Lang.bind(this,
+            this._updateNavigationFlags));
         this._updateNavigationFlags();
 
         let settings = this._browser.get_settings();


### PR DESCRIPTION
Update state of Back/Forward buttons on "notify::uri" signal, in case we are not getting "load-changed" signals correctly.

See https://github.com/endlessm/eos-shell/issues/802
