### PR TITLE
Use resize() to resize the Social Bar

### DIFF
--- a/EosSocial/socialBarView.js
+++ b/EosSocial/socialBarView.js
@@ -81,7 +81,7 @@ const SocialBarSlider = new Lang.Class({
                          height: height };
 
         this._widget.move(geometry.x, geometry.y);
-        this._widget.set_size_request(geometry.width, geometry.height);
+        this._widget.resize(geometry.width, geometry.height);
     },
 
     setInitialValue: function() {


### PR DESCRIPTION
set_size_request() doesn't shrink correctly the widget when the resolution changes.

So let's use resize().

[endlessm/eos-shell#852]
