### PR TITLE
Issues/1925

### DIFF
--- a/eos-social.in
+++ b/eos-social.in
@@ -6,7 +6,7 @@ export LD_LIBRARY_PATH="@pkglibdir@${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
 # Temporary workaround for a crash in WebKitWebProcess
 # https://github.com/endlessm/eos-shell/issues/1738
-export JSC_useJIT=0
+export JSC_maximumInliningDepth=1
 
 if [ "$GJS_DEBUG_OUTPUT" == "" ]; then
     export GJS_DEBUG_OUTPUT=stderr


### PR DESCRIPTION
Set `JSC_maximumInliningDepth=1` instead of disabling JIT altogether as a workaround to avoid crashes in `WebKitWebProcess`.

See https://github.com/endlessm/eos-shell/issues/1738, https://github.com/endlessm/eos-shell/issues/1915 and https://github.com/endlessm/eos-shell/issues/1925 for details.
