### PR TITLE
Make minor style improvements.

### DIFF
--- a/EosSocial/socialBar.js
+++ b/EosSocial/socialBar.js
@@ -77,10 +77,13 @@ const SocialBar = new Lang.Class({
                                      'PropertiesChanged',
                                      propChangedVariant);
 
-        let eventRecorder = EosMetrics.EventRecorder.prototype.get_default();
+        let eventRecorder = EosMetrics.EventRecorder.get_default();
         if (this.Visible)
-            eventRecorder.record_start(EosMetrics.EVENT_SOCIAL_BAR_IS_VISIBLE, null, null);
+            eventRecorder.record_start(EosMetrics.EVENT_SOCIAL_BAR_IS_VISIBLE,
+                                       null, null);
         else
-            eventRecorder.record_stop(EosMetrics.EVENT_SOCIAL_BAR_IS_VISIBLE, null, null);
+            eventRecorder.record_stop(EosMetrics.EVENT_SOCIAL_BAR_IS_VISIBLE,
+                                      null, null);
     }
+
 });


### PR DESCRIPTION
Replace "EventRecorder.prototype.get_default()" with
"EventRecorder.get_default()" for brevity. Wrap lines greater than 80
columns.

[endlessm/eos-sdk#2906]
