### PR TITLE
Force use of WebKit2 version 3.0

### DIFF
--- a/EosSocial/main.js
+++ b/EosSocial/main.js
@@ -1,4 +1,5 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+imports.gi.versions.WebKit2 = '3.0';
 
 const Format = imports.format;
 const Gettext = imports.gettext;


### PR DESCRIPTION
Due to parallel installable versions of WebKit2, gjs will choose a version of
WebKit to load when running the social bar. However, gjs may select a
conflicting version of WebKit2 when loading another module, which can cause a
crash.

[endlessm/eos-sdk#2938]
